### PR TITLE
Fix null lookat

### DIFF
--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -69,17 +69,20 @@ export class Camera extends AnnotationBody {
   * with an id matching the id of an Annotation instance.
   **/
   getLookAt() : object | PointSelector | null {
-    let rawObj = this.getPropertyAsObject("lookAt" )
-    if ( ! rawObj) return null;
+    let rawObj = this.getPropertyAsObject("lookAt" ) ??  null;
+    if ( rawObj == null ) return null;
     
-    let rawType = (rawObj["type"] || rawObj["@type"])
-    if (rawType == "Annotation"){
+    let rawType = (rawObj["type"] || rawObj["@type"]) ??  null;
+    if (rawType == null ) return null;
+        
+    if (rawType == "Annotation")
         return rawObj;
-    }
-    if (rawType == "PointSelector"){
+    else if (rawType == "PointSelector")
         return new PointSelector(rawObj);
+    else{
+        console.error('unidentified value of lookAt ${rawType}');
+        return null;
     }
-    throw new Error('unidentified value of lookAt ${rawType}');
   }  
   get LookAt() : object | null {return this.getLookAt();}
 

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -70,6 +70,8 @@ export class Camera extends AnnotationBody {
   **/
   getLookAt() : object | PointSelector | null {
     let rawObj = this.getPropertyAsObject("lookAt" )
+    if ( ! rawObj) return null;
+    
     let rawType = (rawObj["type"] || rawObj["@type"])
     if (rawType == "Annotation"){
         return rawObj;

--- a/src/JSONLDResource.ts
+++ b/src/JSONLDResource.ts
@@ -41,16 +41,15 @@ export class JSONLDResource {
   {
     let prop = this.getProperty(name);
     
-    if ( prop === null)
-        return prop;
-    else if ( typeof(prop) === 'string')
+    
+    if ( typeof(prop) === 'string')
         return { "id" : prop ,
                  "isIRI" : true
                };
     else if ( prop === Object(prop))
         return prop;
     else{
-        throw new Error("cannot resolve prop as object: " + prop );
+        return null;
     }
   }
 }

--- a/test/tests_3d/xx_whale_comments/c_comment_annotation_camera.js
+++ b/test/tests_3d/xx_whale_comments/c_comment_annotation_camera.js
@@ -59,6 +59,15 @@ describe('c_comment_annotation_camera', function() {
         expect(camera.isPerspectiveCamera).to.equal(true);        
     });
     
+    it('camera has null LookAt property', function(){
+        var annotations = scene.getContent();
+        var body = annotations[3].getBody()[0];
+        var camera = body.isSpecificResource?body.Source:body;
+                      
+
+        expect(camera.LookAt).to.equal(null);       
+    });
+    
     it('all annotation have a body', function(){
         var annotations = scene.getContent();
         for (var i = 0; i < annotations.length; ++i){


### PR DESCRIPTION
The bug reported in issue 18 https://github.com/IIIF-Commons/manifesto-3d/issues/18 has been corrected with a rewrite of the code in Camera.getLookAt accessor. At this commit all unit-tests pass, including the one that specifally tests for the LookAt property being null when a camera orientation is defined through RotateTransform instances