### PR TITLE
Get more content and transform helpers

### DIFF
--- a/src/Annotation.ts
+++ b/src/Annotation.ts
@@ -2,6 +2,7 @@ import { AnnotationMotivation } from "@iiif/vocabulary/dist-commonjs";
 import {
   AnnotationBody,
   AnnotationBodyParser,
+  AnnotationPage,
   IManifestoOptions,
   ManifestResource,
   Resource,
@@ -151,6 +152,9 @@ export class Annotation extends ManifestResource {
     if (!items) return [];
 
     return items
+      .filter(item => item && item.type === 'AnnotationPage')
+      .map(item => new AnnotationPage(item, this.options).getItems())
+      .flat()
       .filter(item => item && item.type === 'Annotation')
       .map(annotation => new Annotation(annotation, this.options));
   }

--- a/src/Annotation.ts
+++ b/src/Annotation.ts
@@ -145,6 +145,18 @@ export class Annotation extends ManifestResource {
   
   get Target(): any {return this. getTarget();}
 
+  // Retrieves target scope content state annotations
+  getScopeContent() : Annotation[] {
+    const items = this.getTarget()?.getScope()?.getTarget()?.items;
+    if (!items) return [];
+
+    return items
+      .filter(item => item && item.type === 'Annotation')
+      .map(annotation => new Annotation(annotation, this.options));
+  }
+
+  get ScopeContent(){return this.getScopeContent();}
+
   getResource(): Resource {
     return new Resource(this.getProperty("resource"), this.options);
   }

--- a/src/AnnotationBody.ts
+++ b/src/AnnotationBody.ts
@@ -8,8 +8,10 @@ import {
   ManifestResource, 
   Transform, 
   TransformParser, 
+  TransformSet, 
   Utils,
-  combineTransforms
+  combineTransformsToMatrix,
+  combineTransformsToTRS
 } from "./internal";
 import { Matrix4 } from "threejs-math";
 
@@ -90,7 +92,17 @@ export class AnnotationBody extends ManifestResource {
     const transform = this.getTransform();
 
     if (transform && transform.length) {
-      return combineTransforms(transform);
+      return combineTransformsToMatrix(transform);
+    }
+    
+    return null;
+  }
+
+  getTransformSet(): TransformSet | null {
+    const transform = this.getTransform();
+
+    if (transform && transform.length) {
+      return combineTransformsToTRS(transform);
     }
     
     return null;

--- a/src/AnnotationBody.ts
+++ b/src/AnnotationBody.ts
@@ -2,7 +2,16 @@ import {
   ExternalResourceType,
   MediaType
 } from "@iiif/vocabulary/dist-commonjs";
-import { AnnotationBodyParser, IManifestoOptions, ManifestResource, Transform, TransformParser, Utils } from "./internal";
+import { 
+  AnnotationBodyParser, 
+  IManifestoOptions, 
+  ManifestResource, 
+  Transform, 
+  TransformParser, 
+  Utils,
+  combineTransforms
+} from "./internal";
+import { Matrix4 } from "threejs-math";
 
  
 /**
@@ -65,10 +74,26 @@ export class AnnotationBody extends ManifestResource {
     return this.getProperty("height");
   }
 
-  getTransform(): Transform[] {
-    return this.getProperty("transform").map((transform) => {
-      return TransformParser.BuildFromJson(transform);
-    });
+  getTransform(): Transform[] | null {
+    const transform = this.getProperty("transform");
+
+    if (transform) {
+      return this.getProperty("transform").map((transform) => {
+        return TransformParser.BuildFromJson(transform);
+      });
+    }
+
+    return null;
+  }
+
+  getTransformMatrix(): Matrix4 | null {
+    const transform = this.getTransform();
+
+    if (transform && transform.length) {
+      return combineTransforms(transform);
+    }
+    
+    return null;
   }
 
   // Some properties may be on this object or (for SpecificResource) in source object

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -1,8 +1,9 @@
 import { 
-    IManifestoOptions, 
-    Utils,
-    AnnotationBody,
-    PointSelector } from "./internal";
+  IManifestoOptions, 
+  Utils,
+  AnnotationBody,
+  PointSelector, 
+  SpecificResource } from "./internal";
 
 export class Camera extends AnnotationBody {
   constructor(jsonld?: any, options?: IManifestoOptions) {
@@ -16,9 +17,9 @@ export class Camera extends AnnotationBody {
   getFieldOfView(): number | undefined 
   {
     if (this.isPerspectiveCamera()){
-        var value = this.getProperty("fieldOfView");
-        if (value) return value;
-        else return 45.0;
+      var value = this.getProperty("fieldOfView");
+      if (value) return value;
+      else return 45.0;
     }
     else return undefined;
   }
@@ -39,11 +40,11 @@ export class Camera extends AnnotationBody {
   getViewHeight(): number | undefined 
   {
     if (this.isOrthographicCamera()){
-        // the term viewHeight for the resource Type was suggested
-        // in https://github.com/IIIF/api/issues/2289#issuecomment-2161608587
-        var value = this.getProperty("viewHeight");
-        if (value) return value;
-        else return undefined;
+      // the term viewHeight for the resource Type was suggested
+      // in https://github.com/IIIF/api/issues/2289#issuecomment-2161608587
+      var value = this.getProperty("viewHeight");
+      if (value) return value;
+      else return undefined;
     }
     else return undefined;
   }
@@ -52,10 +53,11 @@ export class Camera extends AnnotationBody {
   
   
   /**
-  * @return : if not null, is either a PointSelector, or an object
-  * with an id matching the id of an Annotation instance.
+  * @return : if not null, is either a PointSelector, an object
+  * with an id matching the id of an Annotation instance, or a
+  * SpecificResource with a PointSelector .
   **/
-  getLookAt() : object | PointSelector | null {
+  getLookAt() : object | PointSelector | SpecificResource | null {
     let rawObj = this.getPropertyAsObject("lookAt" ) ??  null;
     if ( rawObj == null ) return null;
     
@@ -63,12 +65,15 @@ export class Camera extends AnnotationBody {
     if (rawType == null ) return null;
         
     if (rawType == "Annotation")
-        return rawObj;
+      return rawObj;
     else if (rawType == "PointSelector")
-        return new PointSelector(rawObj);
+      return new PointSelector(rawObj);
+    else if (rawType == "SpecificResource") {
+      return new SpecificResource(rawObj, this.options);
+    }
     else{
-        console.error('unidentified value of lookAt ${rawType}');
-        return null;
+      console.error(`unidentified value of lookAt ${rawType}`);
+      return null;
     }
   }  
   get LookAt() : object | null {return this.getLookAt();}

--- a/src/Canvas.ts
+++ b/src/Canvas.ts
@@ -239,6 +239,22 @@ export class Canvas extends Resource {
     return this.getProperty("index");
   }
 
+  // Annotations not rendered as part of the Canvas
+  // Have non-painting motivations and are listed in Canvas annotations property, not items property
+  getNonContentAnnotations(): Annotation[] {  
+    const annotationPages = ( this.__jsonld.annotations || [] )
+      .filter(annotationPage => annotationPage && annotationPage.type === 'AnnotationPage')
+      .map(annotationPage => new AnnotationPage(annotationPage, this.options)) as AnnotationPage[];  
+    if (!annotationPages.length) return [];
+
+    const annotations = annotationPages
+      .map(page => page.getItems())
+      .flat()
+      .map(annotation => new Annotation(annotation, this.options));
+
+    return annotations;
+  }
+
   getOtherContent(): Promise<AnnotationList[]> {
     const otherContent = Array.isArray(this.getProperty("otherContent"))
       ? this.getProperty("otherContent")

--- a/src/Geometry3d.ts
+++ b/src/Geometry3d.ts
@@ -151,7 +151,7 @@ export function combineTransformsToTRS(transforms: Transform[]): TransformSet {
             const euler = eulerFromRotateTransform(transform as RotateTransform);
             const q1 = new Quaternion().setFromEuler(rotation);
             const q2 = new Quaternion().setFromEuler(euler);
-            q1.multiply(q2);
+            q1.premultiply(q2);
             rotation.setFromQuaternion(q1, "XYZ");
             translation.applyEuler(euler);
         } else if (transform.isScaleTransform) {

--- a/src/Geometry3d.ts
+++ b/src/Geometry3d.ts
@@ -126,7 +126,7 @@ export function combineTransformsToMatrix(transforms: Transform[]): Matrix4 {
             const scale: any = (transform as ScaleTransform).getScale();
             tmat.makeScale(scale.x, scale.y, scale.z);
         }
-        matrix.multiply(tmat);
+        matrix.premultiply(tmat);
     }
 
     return matrix;
@@ -149,7 +149,10 @@ export function combineTransformsToTRS(transforms: Transform[]): TransformSet {
             translation.add(new Vector3(translationTransform.x, translationTransform.y, translationTransform.z));
         } else if (transform.isRotateTransform) {
             const euler = eulerFromRotateTransform(transform as RotateTransform);
-            rotation.set(rotation.x + euler.x, rotation.y + euler.y, rotation.z + euler.z, "XYZ");
+            const q1 = new Quaternion().setFromEuler(rotation);
+            const q2 = new Quaternion().setFromEuler(euler);
+            q1.multiply(q2);
+            rotation.setFromQuaternion(q1, "XYZ");
             translation.applyEuler(euler);
         } else if (transform.isScaleTransform) {
             const scaleTransform: any = (transform as ScaleTransform).getScale();

--- a/src/Light.ts
+++ b/src/Light.ts
@@ -90,7 +90,7 @@ export class Light extends AnnotationBody {
     if (rawType == "PointSelector"){
         return new PointSelector(rawObj);
     }
-    throw new Error('unidentified value of lookAt ${rawType}');
+    throw new Error(`unidentified value of lookAt ${rawType}`);
   }  
   get LookAt() : object | null {return this.getLookAt();}
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -69,4 +69,19 @@ export class Scene extends ManifestResource {
         return null;
   };
 
+  // Annotations not rendered as part of the Canvas
+  // Have non-painting motivations and are listed in Canvas annotations property, not items property
+  getNonContentAnnotations(): Annotation[] {  
+    const annotationPages = ( this.__jsonld.annotations || [] )
+      .filter(annotationPage => annotationPage && annotationPage.type === 'AnnotationPage')
+      .map(annotationPage => new AnnotationPage(annotationPage, this.options)) as AnnotationPage[];  
+    if (!annotationPages.length) return [];
+
+    const annotations = annotationPages
+      .map(page => page.getItems())
+      .flat()
+      .map(annotation => new Annotation(annotation, this.options));
+
+    return annotations;
+  }
 }

--- a/src/SpecificResource.ts
+++ b/src/SpecificResource.ts
@@ -42,8 +42,8 @@ export class SpecificResource extends ManifestResource  {
 
   getScope() : object | Annotation | null
   {
-    var raw =  this.getPropertyAsObject("scope");
-  	if (raw.isIRI) return raw;
+    var raw = this.getPropertyAsObject("scope");
+  	if (raw?.isIRI) return raw;
 
     if (raw) {
       const scope = ([].concat(raw))[0];

--- a/src/SpecificResource.ts
+++ b/src/SpecificResource.ts
@@ -1,6 +1,7 @@
 import {
   IManifestoOptions,
   ManifestResource,
+  Annotation,
   AnnotationBody,
   AnnotationBodyParser,
   Transform,
@@ -38,6 +39,19 @@ export class SpecificResource extends ManifestResource  {
     super(jsonld, options);
     this.isSpecificResource = true;    
   };
+
+  getScope() : object | Annotation | null
+  {
+    var raw =  this.getPropertyAsObject("scope");
+  	if (raw.isIRI) return raw;
+
+    if (raw) {
+      const scope = ([].concat(raw))[0];
+      if (scope && scope["type"] === "Annotation") return new Annotation(scope, this.options);
+    }
+
+    return null;
+  }
   
   getSource() : object | AnnotationBody 
   {

--- a/test/index.js
+++ b/test/index.js
@@ -149,7 +149,12 @@ function run_iiif3d_tests(){
     }); 
      
     describe("9_commenting_annotations" , function(){
+        importTest('astronaut_comment', './tests_3d/9_commenting_annotations/astronaut_comment.js');
         importTest('whale_comment_camera', './tests_3d/9_commenting_annotations/whale_comment_camera.js');
+    }); 
+
+    describe("10_content_state" , function(){
+        importTest('astronaut_comment_scope', './tests_3d/10_content_state/astronaut_comment_scope.js');
     }); 
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -146,6 +146,7 @@ function run_iiif3d_tests(){
         importTest('position_camera_lookat_anno', './tests_3d/2_cameras/positioned_camera_lookat_anno.js');   
         importTest('position_camera_lookat_point', './tests_3d/2_cameras/positioned_camera_lookat_point.js'); 
         importTest('orthographic_camera_lookat_point', './tests_3d/2_cameras/orthographic_camera_lookat_point.js');     
+        importTest('position_camera_lookat_specific_resource', './tests_3d/2_cameras/positioned_camera_lookat_specific_resource.js'); 
     }); 
      
     describe("9_commenting_annotations" , function(){

--- a/test/tests_3d/10_content_state/astronaut_comment_scope.js
+++ b/test/tests_3d/10_content_state/astronaut_comment_scope.js
@@ -1,0 +1,116 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../../dist-commonjs/');
+//var manifests_3d = require('../fixtures/manifests_3d');
+
+
+var ExternalResourceType = require('@iiif/vocabulary/dist-commonjs/').ExternalResourceType;
+var MediaType = require('@iiif/vocabulary/dist-commonjs/').MediaType;
+
+
+let manifest,  sequence, scene , annotation, body, comments;
+
+let manifest_url = {
+        local: "",
+        remote : "https://raw.githubusercontent.com/IIIF/3d/astronaut_comment_scope/manifests/10_content_state/astronaut_comment_scope.json"
+    }.remote;
+
+describe('astronaut_comment_scope', function() {
+
+    it('loads successfully', function(done) {
+        manifesto.loadManifest(manifest_url).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has a sequence', function() {
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+    });
+
+    it('has a scene', function() {
+        scene = sequence.getScenes()[0];
+        expect(scene).to.exist;
+        expect(scene.isScene());
+    });
+    
+    
+    it('with one annotation', function(){
+        var annotations = scene.getContent();
+        expect(annotations.length).to.equal(1);
+        annotation = annotations[0];
+    });
+    
+    it('that target the scene', function(){        
+      var target = annotation.getTarget();
+      target.id.should.exist;
+      target.id.should.equal( scene.id );
+      
+      if (target.isSpecificResource)
+          target.getSource().should.exist;
+    });
+
+    it('has two commenting annotations', function(){
+        comments = scene.getNonContentAnnotations();
+        expect(comments.length).to.equal(2);
+    });
+    
+    it('that target the Scene with PointSelector', function(){
+        const comment = comments[0];
+
+        const target = comment.getTarget();
+        expect( target.isSpecificResource );
+        expect( target.getSource()).to.exist;
+        
+        const selector = target.getSelector();
+        expect( selector.isPointSelector );
+        
+        const location = selector.getLocation();
+        expect(location.x).to.exist;
+        expect(location.y).to.exist;
+        expect(location.z).to.exist;
+    });
+
+    it('and that have scope content state', function(){
+      const comment = comments[0];
+
+      const target = comment.getTarget();
+      expect( target.isSpecificResource );
+
+      const scopeAnnotation = target.getScope();
+      expect(scopeAnnotation.isAnnotation()).to.be.true;
+      expect(scopeAnnotation.getMotivation()[0]).to.equal('contentState');
+    });
+
+    it('with camera annotation', function(){
+      const comment = comments[0];
+
+      const scopeContentItems = comment.getScopeContent();
+      expect(scopeContentItems.length).to.equal(1);
+
+      const annotation = scopeContentItems[0];
+      expect(annotation.isAnnotation()).to.be.true;
+      expect(annotation.getMotivation()[0]).to.equal('painting');
+
+      const body = annotation.getBody()[0];
+      expect(body.isSpecificResource()).to.equal(false);
+      expect(body instanceof manifesto.Camera).to.equal(true);
+      expect(body.isPerspectiveCamera()).to.equal(true);
+
+      const target = annotation.getTarget();
+      expect(target.isSpecificResource);
+      expect(target.getSource()).to.exist;
+      const selector = target.getSelector();
+      expect(selector.isPointSelector);
+      const location = selector.getLocation();
+      location.x.should.equal(0);
+      location.y.should.equal(2.010847091674805);
+      location.z.should.equal(9.11616179783789);
+
+      const lookAtLocation = body.getLookAt()?.getLocation();
+      expect(lookAtLocation.x).to.eq(0);
+      expect(lookAtLocation.y).to.eq(2.0108470916748047);
+      expect(lookAtLocation.z).to.eq(-0.012333005666732798);
+    });
+});

--- a/test/tests_3d/1_basic_model_in_scene/model_origin.js
+++ b/test/tests_3d/1_basic_model_in_scene/model_origin.js
@@ -69,6 +69,11 @@ describe('model_origin', function() {
         
     });
 
+    it('and body has no transforms', function(){        
+        body = annotation.getBody()[0];
+        expect(body.getTransform()).to.not.exist;
+    });
+
     it('body id looks like a model url', function(){        
         body.id.should.include('astronaut.glb');
     });

--- a/test/tests_3d/2_cameras/positioned_camera_lookat_anno.js
+++ b/test/tests_3d/2_cameras/positioned_camera_lookat_anno.js
@@ -44,7 +44,7 @@ describe('positioned_camera_lookat_anno', function() {
         expect(camera instanceof manifesto.Camera).to.equal(true);
         expect(camera.isPerspectiveCamera()).to.equal(true);
         expect(camera.isModel()).to.equal(false,"checking isModel()=false");
-        expect(camera.FieldOfView).to.equal(45.0);
+        
         
         let lookedAt = camera.LookAt;
         expect( lookedAt , "find the lookAt annotation.id?").to.exist;

--- a/test/tests_3d/2_cameras/positioned_camera_lookat_point.js
+++ b/test/tests_3d/2_cameras/positioned_camera_lookat_point.js
@@ -46,7 +46,7 @@ describe('positioned_camera_lookat_point', function() {
         expect(camera instanceof manifesto.Camera).to.equal(true);
         expect(camera.isPerspectiveCamera()).to.equal(true);
         expect(camera.isModel()).to.equal(false,"checking isModel()=false");
-        expect(camera.FieldOfView).to.equal(45.0);
+        
         
         let lookedAt = camera.LookAt;
         expect( lookedAt , "find the lookAt annotation.id?").to.exist;

--- a/test/tests_3d/2_cameras/positioned_camera_lookat_specific_resource.js
+++ b/test/tests_3d/2_cameras/positioned_camera_lookat_specific_resource.js
@@ -46,7 +46,7 @@ describe('positioned_camera_lookat_specific_resource', function() {
         expect(camera instanceof manifesto.Camera).to.equal(true);
         expect(camera.isPerspectiveCamera()).to.equal(true);
         expect(camera.isModel()).to.equal(false,"checking isModel()=false");
-        expect(camera.FieldOfView).to.equal(45.0);
+        
         
         let lookedAt = camera.LookAt;
         expect( lookedAt , "find the lookAt annotation.id?").to.exist;

--- a/test/tests_3d/2_cameras/positioned_camera_lookat_specific_resource.js
+++ b/test/tests_3d/2_cameras/positioned_camera_lookat_specific_resource.js
@@ -1,0 +1,105 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../../dist-commonjs/');
+
+var threejs_math = require('threejs-math');
+
+let manifest, annotations, scene;
+
+let manifest_url = {
+        local: "",
+        remote : "https://raw.githubusercontent.com/IIIF/3d/refs/heads/camera_look_at_specific_resource/manifests/2_cameras/positioned_camera_lookat_specific_resource.json"
+    }.remote;
+
+describe('positioned_camera_lookat_specific_resource', function() {
+
+    it('loads successfully', function(done) {
+        manifesto.loadManifest(manifest_url).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has a sequence', function() {
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+    });
+
+    
+    it('has a scene with two annotation', function(){
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+        scene = sequence.getScenes()[0];
+        expect(scene).to.exist;
+        expect(scene.isScene()).to.be.ok;
+        annotations = scene.getContent();
+        expect(annotations.length).to.equal(2);
+        
+        
+    });
+    
+    it('has 1st annotation a Camera', function(){
+        var camera_anno = annotations[1];
+        let camera = camera_anno.getBody()[0];
+                        
+        expect(camera.isSpecificResource()).to.equal(false);
+        expect(camera instanceof manifesto.Camera).to.equal(true);
+        expect(camera.isPerspectiveCamera()).to.equal(true);
+        expect(camera.isModel()).to.equal(false,"checking isModel()=false");
+        expect(camera.FieldOfView).to.equal(45.0);
+        
+        let lookedAt = camera.LookAt;
+        expect( lookedAt , "find the lookAt annotation.id?").to.exist;
+        
+        let lookedAtLocation = null;
+        if ( lookedAt.isPointSelector ){
+            lookedAtLocation = lookedAt.getLocation();
+        } else if ( lookedAt instanceof manifesto.SpecificResource ) {
+            expect(lookedAt.getSelector()?.isPointSelector).to.equal(true);
+            lookedAtLocation = lookedAt.getSelector().getLocation();
+        } else {
+            let lookedAtAnnotation = scene.getAnnotationById( lookedAt.id );
+            expect( lookedAtAnnotation, "find the lookAt annotation in scene?").to.exist;
+            lookedAtLocation = lookedAtAnnotation.LookAtLocation;
+        }
+        expect( lookedAtLocation ).to.exist;
+        
+        let lookedFromLocation = camera_anno.LookAtLocation ;
+        let direction = lookedAtLocation.clone().sub( lookedFromLocation );
+        let exact_unit_direction = direction.clone().divideScalar( direction.length() );
+        
+        
+        expect( [direction.x, direction.y,direction.z]).to.deep.equal([2.0,-2.0,10.0]);
+        
+        let exact_coords = [exact_unit_direction.x, exact_unit_direction.y,exact_unit_direction.z].join(", ");
+        //console.log(`exact direction ( ${exact_coords} )`)
+        let euler = manifesto.cameraRelativeRotation( direction );
+        
+        // next want to evaluate the result:
+        // 1. create a quaternion representation from the euler
+        // 2. show that athis rotation does 3 things to the unit vectors
+        //    attached to the camera
+        // 2.1 the camera z axis transforms to be parallel to exact_unit_direction
+        // 2.2 the rotated camera x axis is perpendicular to global z axis
+        // 2.3 rotated camera y axis z component is positive
+        let quat = new threejs_math.Quaternion().setFromEuler( euler );
+        
+        let camera_direction = new threejs_math.Vector3( 0.0, 0.0, -1.0 ).applyQuaternion( quat );
+        
+        let camera_direction_coords = [camera_direction.x, camera_direction.y, camera_direction.z ];
+        //console.log(`camera direction ( ${camera_direction_coords} )`)
+        
+        let direction_error = camera_direction.clone().sub(exact_unit_direction);
+        let direction_error_coords = [ direction_error.x, direction_error.y, direction_error.z ];
+        //console.log(`direction error ( ${direction_error_coords} )`)
+        
+        expect( direction_error.length() ).to.be.below( 1.0e-8 );
+        
+        let camera_x_axis = new threejs_math.Vector3( 1.0, 0.0, 0.0 ).applyQuaternion( quat );
+        expect( Math.abs( camera_x_axis.y )).to.be.below(1.0e-8);
+        
+        let camera_y_axis = new threejs_math.Vector3( 0.0, 1.0, 0.0 ).applyQuaternion( quat );
+        expect( camera_y_axis.z ).to.be.above(0.0);
+        
+    });
+});

--- a/test/tests_3d/4_transform_and_position/model_transform_translate_rotate_position.js
+++ b/test/tests_3d/4_transform_and_position/model_transform_translate_rotate_position.js
@@ -47,7 +47,9 @@ describe('model_transform_translate_rotate_position', function() {
         expect( body.isSpecificResource() ).to.be.ok ;
         body.getResourceID().should.include('astronaut.glb');
         body.getFormat().should.equal("application/glb"); // todo correct this when the manifest format is corrected
+    });
 
+    it('with transforms applied to the body', function(){
         var transform = body.getTransform();
         expect(Array.isArray(transform)).to.be.ok;
         expect(transform.length).to.equal(2);
@@ -67,7 +69,12 @@ describe('model_transform_translate_rotate_position', function() {
         expect(rdata.x).to.equal(0.0);
         expect(rdata.y).to.equal(180.0);
         expect(rdata.z).to.equal(0.0);
-    
+
+        const matrix = body.getTransformMatrix();
+        expect(matrix).to.exist;
+
+        const decomposed = manifesto.decomposeMatrix(matrix);
+        expect(decomposed).to.exist;
     });
     
     it('with source pointing to manifest', function(){

--- a/test/tests_3d/4_transform_and_position/model_transform_translate_rotate_position.js
+++ b/test/tests_3d/4_transform_and_position/model_transform_translate_rotate_position.js
@@ -47,6 +47,7 @@ describe('model_transform_translate_rotate_position', function() {
         expect( body.isSpecificResource() ).to.be.ok ;
         body.getResourceID().should.include('astronaut.glb');
         body.getFormat().should.equal("model/gltf-binary");
+    });
 
     it('with transforms applied to the body', function(){
         var transform = body.getTransform();
@@ -80,7 +81,7 @@ describe('model_transform_translate_rotate_position', function() {
         expect( body.isSpecificResource() ).to.be.ok ;
         var source = body.getSource();
         source.id.should.include('astronaut.glb');
-    })
+    });
     
     it('targeting a SpecificResource with PointSelector', function(){
         var target = annotation.getTarget();
@@ -98,6 +99,6 @@ describe('model_transform_translate_rotate_position', function() {
         location.z.should.equal( 0.0);
     });
         
-    
+   
         
 });

--- a/test/tests_3d/9_commenting_annotations/astronaut_comment.js
+++ b/test/tests_3d/9_commenting_annotations/astronaut_comment.js
@@ -1,0 +1,75 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../../dist-commonjs/');
+//var manifests_3d = require('../fixtures/manifests_3d');
+
+
+var ExternalResourceType = require('@iiif/vocabulary/dist-commonjs/').ExternalResourceType;
+var MediaType = require('@iiif/vocabulary/dist-commonjs/').MediaType;
+
+
+let manifest,  sequence, scene , annotation, body;
+
+let manifest_url = {
+        local: "",
+        remote : "https://raw.githubusercontent.com/IIIF/3d/main/manifests/9_commenting_annotations/astronaut_comment.json"
+    }.remote;
+
+describe('astronaut_comment', function() {
+
+    it('loads successfully', function(done) {
+        manifesto.loadManifest(manifest_url).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    it('has a sequence', function() {
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+    });
+
+    it('has a scene', function() {
+        scene = sequence.getScenes()[0];
+        expect(scene).to.exist;
+        expect(scene.isScene());
+    });
+    
+    
+    it('with one annotation', function(){
+        var annotations = scene.getContent();
+        expect(annotations.length).to.equal(1);
+        annotation = annotations[0];
+    });
+    
+    it('that target the scene', function(){        
+      var target = annotation.getTarget();
+      target.id.should.exist;
+      target.id.should.equal( scene.id );
+      
+      if (target.isSpecificResource)
+          target.getSource().should.exist;
+    });
+
+    it('has two commenting annotations', function(){
+        const annotations = scene.getNonContentAnnotations();
+        expect(annotations.length).to.equal(2);
+    });
+    
+    it('targeting the Scene with PointSelector', function(){
+        const annotations = scene.getNonContentAnnotations();
+        const annotation = annotations[0];
+
+        const target = annotation.getTarget();
+        expect( target.isSpecificResource );
+        expect( target.getSource()).to.exist;
+        
+        const selector = target.getSelector();
+        expect( selector.isPointSelector );
+        
+        const location = selector.getLocation();
+        expect(location.x).to.exist;
+        expect(location.y).to.exist;
+        expect(location.z).to.exist;
+    });
+});

--- a/test/tests_3d/core_tests/Geometry3d.js
+++ b/test/tests_3d/core_tests/Geometry3d.js
@@ -132,3 +132,182 @@ describe('Geometry3d: eulerFromRotateTransform', function() {
         
     });
 });
+
+describe('Geometry3d: combineTransformsToTRS', function() {
+    it('combines transform scale -> translate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([translateT, scaleT]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.equal(4);
+        expect(translation.y).to.equal(4);
+        expect(translation.z).to.equal(4);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(0);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform translate -> scale', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([scaleT, translateT]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.equal(2);
+        expect(translation.y).to.equal(2);
+        expect(translation.z).to.equal(2);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(0);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform translate -> rotate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([translateT, rotateT]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(-2, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform rotate -> translate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([rotateT, translateT]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(2, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform translate -> rotate -> scale', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([translateT, rotateT, scaleT]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(-4, 0.000001);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+});

--- a/test/tests_3d/core_tests/Geometry3d.js
+++ b/test/tests_3d/core_tests/Geometry3d.js
@@ -133,6 +133,225 @@ describe('Geometry3d: eulerFromRotateTransform', function() {
     });
 });
 
+describe('Geometry3d: combineTransformsToMatrix', function() {
+    it('combines transform scale -> translate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([translateT, scaleT]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.equal(4);
+        expect(translation.y).to.equal(4);
+        expect(translation.z).to.equal(4);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(0);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform translate -> scale', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([scaleT, translateT]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.equal(2);
+        expect(translation.y).to.equal(2);
+        expect(translation.z).to.equal(2);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(0);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform translate -> rotate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([translateT, rotateT]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(-2, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform rotate -> translate', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([rotateT, translateT]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(2, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform rotate -> rotate', function (){
+        const rotateTFirst = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 30,
+            y: 0,
+            z: 0
+        })
+
+        const rotateTSecond = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 15,
+            y: 0,
+            z: 0
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([rotateTFirst, rotateTSecond]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.be.closeTo(Math.PI / 4, 0.000001);
+        expect(rotation.y).to.be.closeTo(0, 0.000001);
+        expect(rotation.z).to.be.closeTo(0, 0.000001);
+    });
+
+    it('combines transform translate -> rotate -> scale', function (){
+        const translateT = new manifesto.TranslateTransform({
+            type: 'TranslateTransform',
+            x: 2,
+            y: 0,
+            z: 0
+        })
+
+        const rotateT = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 90,
+            z: 0
+        })
+
+        const scaleT = new manifesto.ScaleTransform({
+            type: 'ScaleTransform',
+            x: 2,
+            y: 2,
+            z: 2
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([translateT, rotateT, scaleT]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(-4, 0.000001);
+
+        expect(scale.x).to.equal(2);
+        expect(scale.y).to.equal(2);
+        expect(scale.z).to.equal(2);
+
+        expect(rotation.x).to.equal(0);
+        expect(rotation.y).to.equal(Math.PI / 2);
+        expect(rotation.z).to.equal(0);
+    });
+});
+
 describe('Geometry3d: combineTransformsToTRS', function() {
     it('combines transform scale -> translate', function (){
         const translateT = new manifesto.TranslateTransform({
@@ -268,6 +487,40 @@ describe('Geometry3d: combineTransformsToTRS', function() {
         expect(rotation.x).to.equal(0);
         expect(rotation.y).to.equal(Math.PI / 2);
         expect(rotation.z).to.equal(0);
+    });
+
+    it('combines transform rotate -> rotate', function (){
+        const rotateTFirst = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 30,
+            y: 0,
+            z: 0
+        })
+
+        const rotateTSecond = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 15,
+            y: 0,
+            z: 0
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([rotateTFirst, rotateTSecond]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.be.closeTo(Math.PI / 4, 0.000001);
+        expect(rotation.y).to.be.closeTo(0, 0.000001);
+        expect(rotation.z).to.be.closeTo(0, 0.000001);
     });
 
     it('combines transform translate -> rotate -> scale', function (){

--- a/test/tests_3d/core_tests/Geometry3d.js
+++ b/test/tests_3d/core_tests/Geometry3d.js
@@ -309,6 +309,40 @@ describe('Geometry3d: combineTransformsToMatrix', function() {
         expect(rotation.z).to.be.closeTo(0, 0.000001);
     });
 
+    it('combines transform rotate -> rotate (2)', function (){
+        const rotateTFirst = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 45,
+            z: 0
+        })
+
+        const rotateTSecond = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 60,
+            y: 0,
+            z: 0
+        })
+
+        const matrix = manifesto.combineTransformsToMatrix([rotateTFirst, rotateTSecond]);
+        const { translation, rotation, scale } = manifesto.decomposeMatrix(matrix);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.be.closeTo(Math.PI / 3, 0.000001);
+        expect(rotation.y).to.be.closeTo(Math.PI / 4, 0.000001);
+        expect(rotation.z).to.be.closeTo(0, 0.000001);
+    }); 
     it('combines transform translate -> rotate -> scale', function (){
         const translateT = new manifesto.TranslateTransform({
             type: 'TranslateTransform',
@@ -523,6 +557,39 @@ describe('Geometry3d: combineTransformsToTRS', function() {
         expect(rotation.z).to.be.closeTo(0, 0.000001);
     });
 
+    it('combines transform rotate -> rotate (2)', function (){
+        const rotateTFirst = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 0,
+            y: 45,
+            z: 0
+        })
+
+        const rotateTSecond = new manifesto.RotateTransform({
+            type: 'RotateTransform',
+            x: 60,
+            y: 0,
+            z: 0
+        })
+
+        const { translation, rotation, scale } = manifesto.combineTransformsToTRS([rotateTFirst, rotateTSecond]);
+
+        expect(translation).to.exist;
+        expect(rotation).to.exist;
+        expect(scale).to.exist;
+
+        expect(translation.x).to.be.closeTo(0, 0.000001);
+        expect(translation.y).to.be.closeTo(0, 0.000001);
+        expect(translation.z).to.be.closeTo(0, 0.000001);
+
+        expect(scale.x).to.equal(1);
+        expect(scale.y).to.equal(1);
+        expect(scale.z).to.equal(1);
+
+        expect(rotation.x).to.be.closeTo(Math.PI / 3, 0.000001);
+        expect(rotation.y).to.be.closeTo(Math.PI / 4, 0.000001);
+        expect(rotation.z).to.be.closeTo(0, 0.000001);
+    });
     it('combines transform translate -> rotate -> scale', function (){
         const translateT = new manifesto.TranslateTransform({
             type: 'TranslateTransform',


### PR DESCRIPTION
This PR adds or changes the following functionality: 
* Canvas and Scene expose non-content annotations (listed in `annotations` property instead of `items`) through method `getNonContentAnnotations()`
* Camera `getLookAt` method can now return a SpecificResource in addition to the PointSelector or Annotation URIs previously supported. This allows for a camera to look at points referenced outside the current Scene scope.
* SpecificResource exposes scope information (provided in 'scope' property) through method `getScope()`. The `scope` property is from WADM but has not been used significantly in IIIF previously, but will be mentioned in spec documents and used moving forward for providing annotation scope content state information (i.e., here is the state of the viewer that provides the best context with which to view this annotation in terms of camera placement, etc.). 
* Annotation scope content state information is exposed from the Annotation through the `getScopeContent()` method. This method assumes the Annotation has a target which is a Specific Resource, and that the Specific Resource target has `scope` specified, and that the scope is associated with a list of subsequent annotations. The method returns these scope content state annotations. This occurs in a situation where an Annotation's target has a scope property which is a content state with a list of annotation items, where a client is to understand that these scope annotation items are important for understanding the original Annotation. This allows downstream packages to easily access through scope content state annotation items. 
* Adds transform helper methods to Geometry3D. In particular, there are two methods to help downstream packages get "end state" combinations of transforms, `combineTransformsToMatrix()` and `combineTransformsToTRS()`, which use different methods to combine transforms and **importantly, produce different results**. The method `combineTransformsToMatrix()` builds a 4x4 transformation matrix out of a sequence of Transforms in order and returns the transformation matrix. This method **does not** produce combined transforms in the way the Presentation spec dictates they should be combined, where each transformation is carried out on the local coordinate set or space and the output of that transformation is the input of the next set. The method `combineTransformsToTRS()` **does** produce combined transforms how the spec expects them to be combined, and returns a set of transforms with objects for translation, rotation, and scale. Probably the first method should be removed, but since this is how we discussed handling it in the IIIF commons meeting, it's still there for now. 
* Adds convenience methods to AnnotationBody to get the combined end state transform using the Geometry3D methods above, through methods `getTransformMatrix()` and `getTransformSet` (which uses `combineTransformsToTRS()`).