### PR TITLE
Bug fix to return null for light lookAt getter when there is not look…

### DIFF
--- a/src/Light.ts
+++ b/src/Light.ts
@@ -82,8 +82,12 @@ export class Light extends AnnotationBody {
   * with an id matching the id of an Annotation instance.
   **/
   getLookAt() : object | PointSelector | null {
-    let rawObj = this.getPropertyAsObject("lookAt" )
-    let rawType = (rawObj["type"] || rawObj["@type"])
+    let rawObj = this.getPropertyAsObject("lookAt" ) ??  null;
+    if ( rawObj == null ) return null;
+    
+    let rawType = (rawObj["type"] || rawObj["@type"]) ??  null;
+    if (rawType == null ) return null;
+    
     if (rawType == "Annotation"){
         return rawObj;
     }


### PR DESCRIPTION
Fix for light lookAt function not returning null when no lookAt property is present. Consistent with camera implementation.