### PR TITLE
Added a test 

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,7 @@ function run_iiif3d_tests(){
         importTest('ambient_green_light', './tests_3d/3_lights/ambient_green_light.js');
         importTest('directional light', './tests_3d/3_lights/direction_light_transform_rotate.js');
         importTest('spot light', './tests_3d/3_lights/spotlight_lookat_point.js');
+        importTest('missing transform', './tests_3d/3_lights/multiple_lights_with_intensities_and_colors.js');
     });
     
     describe("2_cameras" , function(){

--- a/test/tests_3d/3_lights/multiple_lights_with_intensities_and_colors.js
+++ b/test/tests_3d/3_lights/multiple_lights_with_intensities_and_colors.js
@@ -1,0 +1,47 @@
+var expect = require('chai').expect;
+var should = require('chai').should();
+var manifesto = require('../../../dist-commonjs/');
+
+
+var ExternalResourceType = require('@iiif/vocabulary/dist-commonjs/').ExternalResourceType;
+var MediaType = require('@iiif/vocabulary/dist-commonjs/').MediaType;
+
+
+let manifest,  sequence, scene , model, body, annotations;
+
+let manifest_url = {
+        local: "http://localhost:3001/model_origin.json",
+        remote : "https://raw.githubusercontent.com/IIIF/3d/main/manifests/3_lights/multiple_lights_with_intensities_and_colors.json"
+    }.remote;
+
+describe('test SpecificResource without transform property', function() {
+
+    it('loads successfully', function(done) {
+        manifesto.loadManifest(manifest_url).then(function(data) {
+            manifest = manifesto.parseManifest(data);
+            done();
+        });
+    });
+
+    
+    it('has a scene with 4 annotation', function(){
+        sequence = manifest.getSequenceByIndex(0);
+        expect(sequence).to.exist;
+        scene = sequence.getScenes()[0];
+        expect(scene).to.exist;
+        expect(scene.isScene()).to.be.ok;
+        annotations = scene.getContent();
+        expect(annotations.length).to.equal(4);
+    });    
+    
+    it('annotation[3] has body SpecificResource with no transform', function(){
+        let body = annotations[3].getBody()[0];
+        expect(body).to.exist;
+        expect(body.isSpecificResource()).to.equal(true);
+        
+        let transform = body.getTransform();
+        expect(transform).to.equal(null);
+    });      
+
+        
+});


### PR DESCRIPTION
Added a unit test based on the newly committed manifest multiple_lights_with_intensities_and_colors

The code at our release 0.6.1 26b4eb4345122f7d4d09e2c77c617251324afbbd was throwing an error on calling getTransform() when applied to a SpecificResource instance that did not have an explicit transform property.

This bug in the master branch has been fixed in the commits since March 17 2025 and at the current commit all tests, including this new test, pass.

