### PR TITLE
Fixing the test part of the GitHub release workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm run build
-      # - run: npm run test
+      - run: npm run test
       # @todo these are not working currently.
       # - run: node pkg-tests/node-load.js
       # - run: node pkg-tests/node-load.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm run build
-      - run: npm run test:3d
+      - run: npm run test
 
   release:
     needs: [build]


### PR DESCRIPTION
Have configured the release and build-test workflows to run the "test" command as defined in package.json. This command runs all of the mocha unit-tests, both those covering the Presentation 3 support as as well as the new 3D unit tests.

Before this commit, the 'release' workflow was running a different command "test:3d" That command has been removed as part of the work to merge the 3D work into the existing iiif-commons/manifest repo.